### PR TITLE
Don't lock layers in layered pdfs

### DIFF
--- a/app/util/pdfplotter.php
+++ b/app/util/pdfplotter.php
@@ -681,7 +681,10 @@ class MgPdfPlotter
                     $mapGroups->GetItem($prevGroupName)->SetVisible(false);
                 }
                 $mapGroups->GetItem($groupName)->SetVisible(true);
-                $this->pdf->startLayer($groupName);
+				$print = true;
+				$view = true;
+				$lock = false;
+                $this->pdf->startLayer($groupName,$print,$view,$lock);
 
                 $filelocation = $this->RenderMap(MgUtils::InToPx($this->printSize->width, $this->dpi),
                                                  MgUtils::InToPx($this->printSize->height, $this->dpi),
@@ -719,7 +722,10 @@ class MgPdfPlotter
                 }
                 $mapLayers->GetItem($layerName)->SetVisible(true);
                 
-                $this->pdf->startLayer($layerName);
+				$print = true;
+				$view = true;
+				$lock = false;
+                $this->pdf->startLayer($groupName,$print,$view,$lock);
 
                 $filelocation = $this->RenderMap(MgUtils::InToPx($this->printSize->width, $this->dpi),
                                                  MgUtils::InToPx($this->printSize->height, $this->dpi),


### PR DESCRIPTION
tcpdf makes all layers locked by default. This means you can not
hide them in acrobat reader (tested with version XI). Thus rendering
the layered option useless.

With this fix layers are not locked by default, and layers show up
correctly in adobe acrobat.
